### PR TITLE
Eth-ws: relaying

### DIFF
--- a/server/ethws_server.go
+++ b/server/ethws_server.go
@@ -4,45 +4,130 @@ import (
 	"context"
 	"fmt"
 	"github.com/gorilla/websocket"
+	"github.com/notional-labs/subnode/config"
+	"github.com/notional-labs/subnode/state"
 	"log"
 	"net/http"
+	"net/url"
+	"sync"
 )
 
 var ethWsServer *http.Server
+var upgrader = websocket.Upgrader{} // use default options
 
-//func ethWsHandle(w http.ResponseWriter, r *http.Request) {
-//	prunedNode := state.SelectPrunedNode(config.ProtocolTypeEthWs)
-//	selectedHost := prunedNode.Backend.Eth // default to pruned node
-//
-//	r.Host = r.URL.Host
-//	state.ProxyMapEthWs[selectedHost].ServeHTTP(w, r)
-//}
+func createWSClient() (*websocket.Conn, error) {
+	prunedNode := state.SelectPrunedNode(config.ProtocolTypeEthWs)
+	selectedHost := prunedNode.Backend.EthWs // default to pruned node
+	targetEthWs, err := url.Parse(selectedHost)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("connecting to %s", targetEthWs.String())
+
+	c, _, err := websocket.DefaultDialer.Dial(targetEthWs.String(), nil)
+	if err != nil {
+		log.Fatal("dial:", err)
+	}
+
+	return c, nil
+}
+
+func ethWsHandle(w http.ResponseWriter, r *http.Request) {
+	wsConServer, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Print("upgrade:", err)
+		return
+	}
+	defer wsConServer.Close()
+
+	var wg sync.WaitGroup
+
+	//---------------------------------
+	// ws-client
+	wsConClient, err := createWSClient()
+	if err != nil {
+		log.Print("error:", err)
+		return
+	}
+	defer wsConClient.Close()
+
+	clientChannel := make(chan []byte) // struct{}
+	serverChannel := make(chan []byte)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		//defer close(clientChannel)
+
+		for {
+			msg := <-clientChannel // receive msg from clientChannel
+
+			// relay to server
+			log.Println("relay to server")
+			err = wsConServer.WriteMessage(websocket.TextMessage, msg)
+			if err != nil {
+				log.Println("relay to server:", err)
+				break
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		//defer close(serverChannel)
+
+		for {
+			msg := <-serverChannel // receive msg from serverChannel
+
+			// relay to client
+			log.Println("relay to client")
+			err = wsConClient.WriteMessage(websocket.TextMessage, msg)
+			if err != nil {
+				log.Println("relay to client:", err)
+				break
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			_, msg, err := wsConClient.ReadMessage()
+			if err != nil {
+				log.Println("ws-client read:", err)
+				break
+			}
+			log.Printf("ws-client recv: %s", msg)
+			clientChannel <- msg // send msg to clientChannel
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			_, msg, err := wsConServer.ReadMessage()
+			if err != nil {
+				log.Println("ws-server read:", err)
+				break
+			}
+			log.Printf("ws-server recv: %s", msg)
+			serverChannel <- msg // send msg to serverChannel
+		}
+	}()
+
+	wg.Wait()
+}
 
 func StartEthWsServer() {
 	fmt.Println("StartEthWsServer...")
 
-	var upgrader = websocket.Upgrader{} // use default options
-
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		c, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			log.Print("upgrade:", err)
-			return
-		}
-		defer c.Close()
-		for {
-			mt, message, err := c.ReadMessage()
-			if err != nil {
-				log.Println("read:", err)
-				break
-			}
-			log.Printf("recv: %s", message)
-			err = c.WriteMessage(mt, message)
-			if err != nil {
-				log.Println("write:", err)
-				break
-			}
-		}
+		ethWsHandle(w, r)
 	}
 
 	// handle all requests to your server using the proxy

--- a/server/ethws_server.go
+++ b/server/ethws_server.go
@@ -26,7 +26,7 @@ func createWSClient() (*websocket.Conn, error) {
 
 	c, _, err := websocket.DefaultDialer.Dial(targetEthWs.String(), nil)
 	if err != nil {
-		log.Printf("dial:", err)
+		log.Println("dial err:", err)
 		return nil, err
 	}
 

--- a/state/state.go
+++ b/state/state.go
@@ -22,15 +22,14 @@ type BackendState struct {
 }
 
 var (
-	PoolRpc       []*BackendState
-	PoolApi       []*BackendState
-	PoolGrpc      []*BackendState
-	PoolEth       []*BackendState
-	PoolEthWs     []*BackendState
-	ProxyMapRpc   = make(map[string]*httputil.ReverseProxy)
-	ProxyMapApi   = make(map[string]*httputil.ReverseProxy)
-	ProxyMapEth   = make(map[string]*httputil.ReverseProxy)
-	ProxyMapEthWs = make(map[string]*httputil.ReverseProxy)
+	PoolRpc     []*BackendState
+	PoolApi     []*BackendState
+	PoolGrpc    []*BackendState
+	PoolEth     []*BackendState
+	PoolEthWs   []*BackendState
+	ProxyMapRpc = make(map[string]*httputil.ReverseProxy)
+	ProxyMapApi = make(map[string]*httputil.ReverseProxy)
+	ProxyMapEth = make(map[string]*httputil.ReverseProxy)
 )
 
 func Init() {
@@ -40,7 +39,6 @@ func Init() {
 		rpcItem := PoolRpc[i]
 		apiItem := PoolApi[i]
 		ethItem := PoolEth[i]
-		ethWsItem := PoolEthWs[i]
 
 		// rpc
 		targetRpc, err := url.Parse(rpcItem.Name)
@@ -62,13 +60,6 @@ func Init() {
 			panic(err)
 		}
 		ProxyMapEth[ethItem.Name] = httputil.NewSingleHostReverseProxy(targetEth)
-
-		// eth-ws
-		targetEthWs, err := url.Parse(ethWsItem.Name)
-		if err != nil {
-			panic(err)
-		}
-		ProxyMapEthWs[ethWsItem.Name] = httputil.NewSingleHostReverseProxy(targetEthWs)
 	}
 }
 

--- a/test/test.config.evmos.yaml
+++ b/test/test.config.evmos.yaml
@@ -3,7 +3,7 @@ upstream:
     api: "http://api-evmos-ia.cosmosia.notional.ventures:80"
     grpc: "grpc-evmos-ia.cosmosia.notional.ventures:9090"
     eth: "http://jsonrpc-evmos-ia.cosmosia.notional.ventures:80"
-    ethws: "http://jsonrpc-evmos-ia.cosmosia.notional.ventures:80"
+    ethws: "ws://jsonrpc-evmos-ia.cosmosia.notional.ventures:80/websocket/"
     blocks: [362880]
   - rpc: "http://rpc-evmos-archive-sub-ia.cosmosia.notional.ventures:80"
     api: "http://api-evmos-archive-sub-ia.cosmosia.notional.ventures:80"


### PR DESCRIPTION
use ws relaying so that we could implement the logic later:
- eth_subscribe, eth_unsubscribe: relaying to pruned node ws
- other methods: proxy to eth-jsonrpc

https://github.com/notional-labs/subnode/issues/46